### PR TITLE
Filter identities by default msisdns

### DIFF
--- a/lib/identity_store.js
+++ b/lib/identity_store.js
@@ -99,21 +99,36 @@ IdentityStore.prototype = {
             });
     },
 
-    /**:IdentityStore.get_or_create(address, options)
+    /**:IdentityStore.get_identity_by_address(address, include_inactive, default_addr)
     Gets an identity by an address if it exists
 
     :param object address: {address_type: address}
                 eg. {'msisdn': '0821234444'}; {'email': 'me@example.com'}
-    :param object options: data/payload for POST request (create function)
-    :param boolean include_inactive:
+    :param str include_inactive:
                 pass in `true` if you want to return identities where the
                 address has been marked as inactive
+    :param str default_addr:
+                pass in `False` if you want to return identities where the address
+                is not the default address
     */
-    get_identity_by_address: function(address, include_inactive) {
+    get_identity_by_address: function(address, include_inactive, default_addr) {
         include_inactive = include_inactive || "False";  // default to False
+        default_addr = default_addr || "True"; // default to True
 
         return this.list_by_address(address, include_inactive)
             .then(function(identities_found) {
+                if (default_addr === "True") {
+                    var address_type = Object.keys(address)[0];
+                    var address_val = address[address_type];
+                    identities_found.results = identities_found.results.filter(function(identity) {
+                        // If any of the other addresses are default, then this identity
+                        // shouldn't be included
+                        return Object.keys(identity.details.addresses[address_type]).every(function(address){
+                            var details = identity.details.addresses[address_type][address];
+                            return address === address_val || details.default !== true;
+                        });
+                    });
+                }
                 if (identities_found.results.length > 0) {
                     // there should always just be 0 or 1 result, but return
                     // only the first result in case something went wrong
@@ -132,8 +147,11 @@ IdentityStore.prototype = {
     :param boolean include_inactive:
                 pass in `true` if you want to return identities where the
                 address has been marked as inactive
+    :param str default_addr:
+                pass in `False` if you want to return identities where the
+                address is not the default address
     */
-    get_or_create_identity: function(address, options, include_inactive) {
+    get_or_create_identity: function(address, options, include_inactive, default_addr) {
         var self = this;  // necessary to circumvent subsequent binding loss
 
         include_inactive = include_inactive || "False";  // default to False

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -791,7 +791,22 @@ module.exports = function() {
                 "data": {
                     "next": null,
                     "previous": null,
-                    "results": []
+                    "results": [{
+                        "url": "http://is.localhost:8001/api/v1/identities/cb245673-aa41-4302-ac47-00000000001/",
+                        "id": "cb245673-aa41-4302-ac47-00000000001",
+                        "version": 1,
+                        "details": {
+                            "default_addr_type": "msisdn",
+                            "addresses": {
+                                "msisdn": {
+                                    "08212345678": {"default": true},
+                                    "08212345679": {"default": false}
+                                }
+                            }
+                        },
+                        "created_at": "2016-06-21T06:13:29.693272Z",
+                        "updated_at": "2016-06-21T06:13:29.693298Z"
+                    }]
                 }
             }
         },


### PR DESCRIPTION
This PR adds a `default_addr` parameter that defaults to True. If it's True, then only the identities whose default address is the desired address will be returned